### PR TITLE
fixed monitoring other than 'components' namespace

### DIFF
--- a/controllers/.vscode/settings.json
+++ b/controllers/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": ""
+}

--- a/controllers/buildControllers.sh
+++ b/controllers/buildControllers.sh
@@ -1,4 +1,4 @@
-docker build --file component-IngressController-dockerfile -t tmforumodacanvas/component-controller:0.11.0 -t tmforumodacanvas/component-controller:master -t tmforumodacanvas/component-controller:latest .
+docker build --file component-IngressController-dockerfile -t tmforumodacanvas/component-controller:0.12.0 -t tmforumodacanvas/component-controller:master -t tmforumodacanvas/component-controller:latest .
 docker push tmforumodacanvas/component-controller --all-tags
 # TODO We'll add the wso2 controller back in when we've refactored it
 #docker build --file component-wso2Controller-dockerfile -t tmforumodacanvas/component-controller-wso2:0.9 -t tmforumodacanvas/component-controller-wso2:latest -t tmforumodacanvas/component-controller-wso2:master .

--- a/controllers/component-IngressController-dockerfile
+++ b/controllers/component-IngressController-dockerfile
@@ -4,4 +4,4 @@ RUN pip install kubernetes==17.14.0a1
 RUN pip install cloudevents
 ADD . /
 ADD securityController/secconkeycloak.py /
-CMD kopf run --namespace=components --standalone componentOperator/componentOperator.py apiOperatorSimpleIngress/apiOperatorSimpleIngress.py securityController/securityControllerKeycloak.py
+CMD kopf run --namespace=$COMPONENT_NAMESPACE --standalone componentOperator/componentOperator.py apiOperatorSimpleIngress/apiOperatorSimpleIngress.py securityController/securityControllerKeycloak.py

--- a/controllers/component-apigController-dockerfile
+++ b/controllers/component-apigController-dockerfile
@@ -2,4 +2,4 @@ FROM python:3.7
 RUN pip install kopf
 RUN pip install kubernetes
 ADD . /
-CMD kopf run --standalone apiOperator-apig/apiOperator-apig.py
+CMD kopf run --namespace=$COMPONENT_NAMESPACE --standalone apiOperator-apig/apiOperator-apig.py

--- a/controllers/component-wso2Controller-dockerfile
+++ b/controllers/component-wso2Controller-dockerfile
@@ -2,4 +2,4 @@ FROM python:3.7
 RUN pip install kopf
 RUN pip install kubernetes
 ADD . /
-CMD kopf run --standalone componentOperator/componentOperator.py apiOperator-wso2/apiOperator-wso2.py  securityController/securityControllerKeycloak.py
+CMD kopf run --namespace=$COMPONENT_NAMESPACE --standalone componentOperator/componentOperator.py apiOperator-wso2/apiOperator-wso2.py  securityController/securityControllerKeycloak.py

--- a/controllers/componentOperator/componentOperator.py
+++ b/controllers/componentOperator/componentOperator.py
@@ -22,6 +22,10 @@ kopf_logger.setLevel(logging.WARNING)
 logger = logging.getLogger('ComponentOperator')
 logger.setLevel(int(logging_level))
 
+#get namespace to monitor
+component_namespace = os.environ.get('COMPONENT_NAMESPACE', 'components')
+logger.info(f'Monitoring namespace %s', component_namespace)
+
 # Constants
 HTTP_CONFLICT = 409
 HTTP_NOT_FOUND = 404


### PR DESCRIPTION
Fixed the issue that the canvas only worked with components in the 'components' namespace. You can now run a separate canvas and set the components namespace that you want to monitor (using the monitorednamespaces value in https://github.com/tmforum-oda/oda-canvas-charts/blob/master/canvas/charts/controller/values.yaml)

Closes #28 