### PR TITLE
compcrdwebhook : Supporting arm architectures

### DIFF
--- a/webhooks/builddockerfile.sh
+++ b/webhooks/builddockerfile.sh
@@ -1,3 +1,7 @@
-docker build -t tmforumodacanvas/compcrdwebhook:0.5.1 -f webhook-dockerfile . 
-#docker build -t tmforumodacanvas/compcrdwebhook:0.3 -t tmforumodacanvas/compcrdwebhook:latest -f webhook-dockerfile . 
-docker push tmforumodacanvas/compcrdwebhook --all-tags
+#buildx is required for this to work
+#docker build -t tmforumodacanvas/compcrdwebhook.3 -t tmforumodacanvas/compcrdwebhook:latest -f webhook-dockerfile .
+#docker push tmforumodacanvas/compcrdwebhook --all-tags
+
+# The following uses buildx to build for multiple platforms (*nix/amd64 and arm64)
+# please read this as well https://github.com/docker/buildx/issues/59 , doesn't change much but it's good to know
+docker buildx build -t "tmforumodacanvas/compcrdwebhook:0.5.1" --platform "linux/amd64,linux/arm64" -f webhook-dockerfile . --push


### PR DESCRIPTION
The following adds support for building the compwebhook for other architectures as well. They will be bundled with the same tag.

It uses docker `buildx`, and it can be used by any machine an build for multiple architectures without even having to own a machine of that architecture.

fixes https://github.com/tmforum-oda/oda-ca/issues/99